### PR TITLE
Request only the most recent METAR per station. Skip deduplication that is no longer necessary.

### DIFF
--- a/live_sectional.py
+++ b/live_sectional.py
@@ -40,7 +40,7 @@ mydict = {
 }
 
 
-url = "https://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=xml&hoursBeforeNow=1.5&stationString="
+url = "https://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=xml&hoursBeforeNow=1.5&mostRecent=true&stationString="
 for airportcode in airports:
 	if airportcode == "NULL":
 		continue
@@ -64,14 +64,10 @@ for metar in root.iter('METAR'):
 		#print "Skipping"
 		continue
 
-	flightCateory = metar.find('flight_category').text
+	flightCategory = metar.find('flight_category').text
 	#print stationId + " " + flightCateory
 	#logfile.write("\n"+ stationId + " " + flightCateory)
-	if stationId in mydict:
-            continue
-	#	logfile.write("\nduplicate, only save first metar")
-	else:
-		mydict[stationId] = flightCateory
+	mydict[stationId] = flightCategory
 
 
 


### PR DESCRIPTION
fixes #14

Take advantage of the mostRecent=true parameter to the aviationweather.gov website to take care of the duplication, rather than checking it within the app.