### PR TITLE
Add mostRecentForEachStation param to NWS API Call, remove dictonary tracking duplicates

### DIFF
--- a/live_sectional.py
+++ b/live_sectional.py
@@ -40,7 +40,7 @@ mydict = {
 }
 
 
-url = "https://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=xml&hoursBeforeNow=1.5&stationString="
+url = "https://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=xml&hoursBeforeNow=1.5&mostRecentForEachStation=true&stationString="
 for airportcode in airports:
 	if airportcode == "NULL":
 		continue
@@ -67,11 +67,7 @@ for metar in root.iter('METAR'):
 	flightCateory = metar.find('flight_category').text
 	#print stationId + " " + flightCateory
 	#logfile.write("\n"+ stationId + " " + flightCateory)
-	if stationId in mydict:
-            continue
-	#	logfile.write("\nduplicate, only save first metar")
-	else:
-		mydict[stationId] = flightCateory
+	mydict[stationId] = flightCateory
 
 
 


### PR DESCRIPTION
This ACTUALLY fixes #14. The previous fix, in PR13, grabbed the most recent METAR for ANY station in the list. This will grab the most recent METAR for EACH station in the list, assuming it meets the other criteria (namely, that it is less than 1.5 hours old.

Sample URL that could be called, requesting the most recent METAR for KLAX and KORD, given a time of the last 3 hours (we would assume at least 6 METARs to be returned without the parameter, but we'll only get 2 back with it):

https://www.aviationweather.gov/adds/dataserver_current/httpparam?dataSource=metars&requestType=retrieve&format=xml&hoursBeforeNow=3&mostRecentForEachStation=true&stationString=KORD,KLAX